### PR TITLE
Fix routing and back button issue

### DIFF
--- a/src/documents.js
+++ b/src/documents.js
@@ -72,6 +72,7 @@ export class Documents {
   }
 
   activate(params) {
+    // console.debug(`activate is running with params: ${JSON.stringify(params)}`);
     this.params = params;
     if (params.q) {
       this.query = params.q;

--- a/src/documents.js
+++ b/src/documents.js
@@ -28,6 +28,7 @@
  */
 import { inject } from 'aurelia-framework';
 import {Router} from 'aurelia-router';
+import {activationStrategy} from 'aurelia-router';
 
 @inject(Router)
 export class Documents {
@@ -47,6 +48,10 @@ export class Documents {
     this.router = router;
   }
 
+  determineActivationStrategy() {
+    return activationStrategy.replace;
+  }
+
   buildState() {
     this.state = {
       q: this.query
@@ -58,7 +63,7 @@ export class Documents {
 
   submit() {
     this.buildState();
-    this.router.navigateToRoute('documents', this.state, {replace: true});
+    this.router.navigateToRoute('documents', this.state);
   }
 
 


### PR DESCRIPTION
The issue was given the single route pattern 'documents', Aurelia couldn't figure out that anything has changed. Solution is to use the [activationStrategy](https://github.com/aurelia/documentation/blob/master/English/docs.md#reusing-an-existing-vm)

Another problem was `{replace: true}` being passed to router navigation method. I think this causes the new url to replace current one in history, so it messes up back button navigation.
